### PR TITLE
2016 launch

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
             <h3>Who should submit a proposal?</h3>
             <p>
               <b>You. Your friends. Your friends' friends.</b> Everyone's welcome! Anyone with any level of Python knowledge
-              is a candidate for a good topic at this conference. If you're a first time speaker with limited experiend, contact us -
+              is a candidate for a good topic at this conference. If you're a first time speaker with limited experiend, <a href="mailto:cfp@pycon.se">contact us</a> -
               we will help you out! As we get attendees of all kinds, we need speakers of all kinds. In all ways and manners,
               we try to assemble the most diverse conference we can, and we do that with your help.
             </p>

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -68,27 +68,30 @@
                 <h3>Gold sponsor (limited to 2)</h3>
                 <p>75 000 SEK</p>
                 <ul>
-                  <li>Guaranteed space for booth at the venue</li>
+					   <li>
+                    Rollup on display in each of the lecture
+                    halls, beside the stage for the entire conference.
+                  </li>
+
+						<li>
+                      5 (five) minutes of stage time at the beginning of either
+                      the first or second day - first come, first served.
+                  </li>
                   <li>
-                    5 corporate tickets (transferrable)
+							Booth at the venue (Guaranteed space)
+						</li>
+						<li>
+                    Company logo embodied on the conference bag or
+                    lanyard
                   </li>
                   <li>
                     Full-page ad in conference brochure
                   </li>
                   <li>
-                    Company logo embodied on the conference bag or
-                    lanyard
-                  </li>
-                  <li>
-                    Rollup on display in each of the lecture
-                    halls, beside the stage.
-                  </li>
-                  <li>
                     Can get a job ad on the homepage and in the brochure.
                   </li>
-                  <li>
-                      5 (five) minutes of stage time at the beginning of either
-                      the first or second day - first come, first served.
+						<li>
+                    5 corporate tickets (transferrable)
                   </li>
                 </ul>
               </div>
@@ -97,17 +100,18 @@
                 <p>35 000 SEK</p>
                 <ul>
                   <li>
-                    Booth at the venue (first come, first served)
+							Booth at the venue (first come, first served)
                   </li>
                   <li>
-                    2 corporate tickets
+							Half-page ad in the conference brochure
                   </li>
                   <li>
-                    Half-page ad in the conference brochure
+							Can get a job ad on the homepage and in the brochure.
                   </li>
-                  <li>
-                      Can get a job ad on the homepage and in the brochure.
+						<li>
+							2 corporate tickets
                   </li>
+
                 </ul>
               </div>
               <div class="col-sm-4">
@@ -115,11 +119,12 @@
                 <p>10 000 SEK</p>
                 <ul>
                   <li>
+                    Mention in the conference brochure, with logotype and home page
+                  </li>
+						<li>
                     1 corporate ticket
                   </li>
-                  <li>
-                    Mention with logotype in the conference brochure and home page
-                  </li>
+
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
Re-arranged the perks on the sponsor page and added a link to cfp@pycon.se on the main-page under "If you're a first time speaker..."