### PR TITLE
Responsive images for mobile devices: Replace HTML tag width attributes with CSS classes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -576,6 +576,27 @@ input[type='checkbox'] {
 }
 /* end of fade animation for image slider - magnific popup */
 
+/* Logo Image Rules */
+.img-responsive {
+    max-width: 80vw;
+}
+
+.w200 {
+    width: 200px;
+}
+
+.w260 {
+    width: 260px;
+}
+
+.w300 {
+    width: 300px;
+}
+
+.w350 {
+    width: 350px;
+}
+/* end of logo image rules */
 
 /*************************/
 /*     02. Preloader     */

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    
+
     <!-- SEO Meta Tags -->
     <meta name="description" content="Aria is a business focused HTML landing page template built with Bootstrap to help you create lead generation websites for companies and their services.">
     <meta name="author" content="Inovatik">
@@ -21,12 +21,12 @@
         <meta name="author" content="Python Sverige">
         <meta name="keywords" content="python pycon django conference meetup">
         <meta name="description" content="PyCon Sweden 2020 will take place between November 12 - 13 Online. Register now!" />
-      
+
         <meta property="og:image" content="http://www.pycon.se/images/linkedin-thumbnail.png" />
         <meta property="og:image:type" content="image/png" />
         <meta property="og:image:width" content="180" />
         <meta property="og:image:height" content="95" />
-      
+
         <meta name="twitter:card" content="summary_large_image">
         <meta name="twitter:site" content="@pyconse">
         <meta name="twitter:title" content="PyCon Sweden 2020">
@@ -35,7 +35,7 @@
 
     <!-- Website Title -->
     <title>PyCon Sweden</title>
-    
+
     <!-- Styles -->
     <link href="https://fonts.googleapis.com/css?family=Montserrat:500,700&display=swap&subset=latin-ext" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600&display=swap&subset=latin-ext" rel="stylesheet">
@@ -44,12 +44,12 @@
     <link href="css/swiper.css" rel="stylesheet">
     <link href="css/magnific-popup.css" rel="stylesheet">
     <link href="css/styles.css" rel="stylesheet">
-	
+
     <!-- Favicon  -->
     <link rel="icon" href="images/favicon.ico">
 </head>
 <body data-spy="scroll" data-target=".fixed-top">
-    
+
     <!-- Preloader -->
 	<div class="spinner-wrapper">
         <div class="spinner">
@@ -70,7 +70,7 @@
                 <!-- Image Logo -->
                 <!-- <a class="navbar-brand logo-image" href="index.html"><img src="images/PyCon_logo_2019.png" alt="alternative"></a> -->
             </div> <!-- end of col -->
-        
+
         <!-- Mobile Menu Toggle Button -->
             <div class="col-2">
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
@@ -532,12 +532,12 @@
                     <div class="row">
                         <div class="col-lg-6 pb-4 d-flex justify-content-center align-items-center">
                             <a href="https://funnel.io/" target="_blank">
-                                <img src="images/sponsors/funnel-logo.png" alt="" class="img-responsive" width="300">
+                                <img src="images/sponsors/funnel-logo.png" alt="" class="img-responsive w300">
                             </a>
                         </div>
                         <div class="col-lg-5 pb-4 d-flex justify-content-center align-items-center">
                             <a href="https://career.hm.com/content/hmcareer/en_gb/workingathm/what-can-you-do-here/Head%20Office%20Sweden/BusinessTech.html" target="_blank">
-                                <img src="images/sponsors/LogotypeH&MGroup.jpg" alt="" class="img-responsive" width="300">
+                                <img src="images/sponsors/LogotypeH&MGroup.jpg" alt="" class="img-responsive w300">
                             </a>
                         </div>
                     </div>
@@ -545,17 +545,17 @@
                     <div class="row">
                         <div class="col-lg-4 pb-4 d-flex justify-content-center align-items-center">
                             <a href="https://jobs.lever.co/klarna?lever-source%5B0%5D=pyconse2020&team=Engineering" target="_blank">
-                                <img src="images/sponsors/Klarna_PaymentBadge_OutsideCheckout_Pink.png" alt="" class="img-responsive" width="260">
+                                <img src="images/sponsors/Klarna_PaymentBadge_OutsideCheckout_Pink.png" alt="" class="img-responsive w260">
                             </a>
                         </div>
                         <div class="col-lg-4 pb-4 d-flex justify-content-center align-items-center">
                             <a href="https://www.sigmait.se" target="_blank">
-                                <img src="images//sponsors/Sigma-Outline_svart_pycon.png" alt="" class="img-responsive" width="260">
+                                <img src="images//sponsors/Sigma-Outline_svart_pycon.png" alt="" class="img-responsive w260">
                             </a>
                         </div>
                         <div class="col-lg-4 pb-4 d-flex justify-content-center align-items-center">
                             <a href="https://46elks.se/" target="_blank">
-                                <img src="images/sponsors/46elks-logo-blue.png" alt="" class="img-responsive" width="200">
+                                <img src="images/sponsors/46elks-logo-blue.png" alt="" class="img-responsive w200">
                             </a>
                         </div>
                     </div>
@@ -591,7 +591,7 @@
                             <div class="col-lg-5 col-xl-6">
                                 <div class="image-container">
                                     <a href="https://46elks.se/jobs" target="_blank">
-                                        <img src="images/sponsors/46elks-logo-blue.png" alt="" class="img-responsive" width="260">
+                                        <img src="images/sponsors/46elks-logo-blue.png" alt="" class="img-responsive w260">
                                     </a>
                                 </div> <!-- end of image-container -->
                             </div>
@@ -625,7 +625,7 @@
                             <div class="col-lg-5 col-xl-6">
                                 <div class="image-container">
                                     <a href="https://career.hm.com/content/hmcareer/en_gb/workingathm/what-can-you-do-here/Head%20Office%20Sweden/BusinessTech.html" target="_blank">
-                                        <img src="images//sponsors/LogotypeH&MGroup.jpg" alt="" class="img-responsive" width="260">
+                                        <img src="images//sponsors/LogotypeH&MGroup.jpg" alt="" class="img-responsive w260">
                                     </a>
                                 </div> <!-- end of image-container -->
                             </div>
@@ -661,7 +661,7 @@
                             <div class="col-lg-5 col-xl-6">
                                 <div class="image-container">
                                     <a href="https://jobs.lever.co/klarna?lever-source%5B0%5D=pyconse2020&team=Engineering" target="_blank">
-                                        <img src="images/sponsors/Klarna_PaymentBadge_OutsideCheckout_Pink.png" alt="" class="img-responsive" width="260">
+                                        <img src="images/sponsors/Klarna_PaymentBadge_OutsideCheckout_Pink.png" alt="" class="img-responsive w260">
                                     </a>
                                 </div> <!-- end of image-container -->
                             </div>
@@ -688,7 +688,7 @@
                             <div class="col-lg-5 col-xl-6">
                                 <div class="image-container">
                                     <a href="https://funnel.io" target="_blank">
-                                        <img src="images/sponsors/funnel-logo.png" alt="" class="img-responsive" width="350">
+                                        <img src="images/sponsors/funnel-logo.png" alt="" class="img-responsive w350">
                                     </a>
                                 </div> <!-- end of image-container -->
                             </div>
@@ -727,7 +727,7 @@
                             <div class="col-lg-5 col-xl-6">
                                 <div class="image-container">
                                     <a href="https://www.sigmait.se" target="_blank">
-                                        <img src="images//sponsors/Sigma-Outline_svart_pycon.png" alt="" class="img-responsive" width="260">
+                                        <img src="images//sponsors/Sigma-Outline_svart_pycon.png" alt="" class="img-responsive w260">
                                     </a>
                                 </div> <!-- end of image-container -->
                             </div>
@@ -819,7 +819,7 @@
                         </div>
                         <!-- end of counter -->
 
-                    </div> <!-- end of text-container -->      
+                    </div> <!-- end of text-container -->
                 </div> <!-- end of col -->
             </div> <!-- end of row -->
         </div> <!-- end of container -->
@@ -1122,7 +1122,7 @@
                 </div> <!-- end of col -->
             </div> <!-- end of row -->
         </div> <!-- end of container -->
-    </div> <!-- end of footer -->  
+    </div> <!-- end of footer -->
     <!-- end of footer -->
 
 
@@ -1135,10 +1135,10 @@
                 </div> <!-- end of col -->
             </div> <!-- enf of row -->
         </div> <!-- end of container -->
-    </div> <!-- end of copyright --> 
+    </div> <!-- end of copyright -->
     <!-- end of copyright -->
-    
-    	
+
+
     <!-- Scripts -->
     <script src="js/jquery.min.js"></script> <!-- jQuery for Bootstrap's JavaScript plugins -->
     <script src="js/popper.min.js"></script> <!-- Popper tooltip library for Bootstrap -->
@@ -1171,7 +1171,7 @@ var x = setInterval(function() {
   var seconds = Math.floor((distance % (1000 * 60)) / 1000);
 
   // Display the result in an element with id="demo"
-  document.getElementById("demo").innerHTML = 
+  document.getElementById("demo").innerHTML =
       "<div class=\"col-md-2 pb-2 d-flex justify-content-center align-items-center\"></div>" +
       "<div class=\"col-md-2 pb-2 d-flex justify-content-center align-items-center\">" + days + " Days </div>" +
       "<div class=\"col-md-2 pb-2 d-flex justify-content-center align-items-center\">" + hours + " Hours </div>" +


### PR DESCRIPTION
There was an issue with logo images of a too large width "jutting out" on mobile devices, causing a white strip that ran along the right side of the actual content of the website. See the image below.

![pycon-sweden-mobile-issue](https://user-images.githubusercontent.com/65363390/97103836-6b498400-16af-11eb-8cdf-491a066edc17.jpg)

Part of the issue is that logo images' widths are specified directly in the HTML with tag attributes (e. g. `width=200px`), which makes them hard to override in a clean manner. Also, all of the logo images share the 'img-responsive' class, but there are no CSS rules for this class in actively used stylesheets. (the repo's 'table.css' file has a single rule for '.img-responsive.img-center', but 'table.css' isn't linked to from any of the HTML files)

In order to tackle the above issues:
1. Remove the tag width attributes, and replace them with classes (e. g. 'w360')
2. In 'styles.css', add CSS rules that are specific for the particular classes (e. g. for 'w360', `width: 360px`).
3. Add a CSS rule for the 'img-responsive' class of 'max-width: 80vw'. 
(in addition to this, there are a few edits resulting from Atom automatically removing trailing spaces that were in the HTML file)

After the above changes, viewing the site on a mobile device seems to work as expected.